### PR TITLE
Feat: Fetch devices list from Cloudflare Worker

### DIFF
--- a/app/devices/page.tsx
+++ b/app/devices/page.tsx
@@ -10,11 +10,23 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { TriangleAlert } from "lucide-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
 
 export const metadata: Metadata = {
   title: "Devices",
   description: "What do I (used to) use?",
 };
+
+type devicesJsonResponse = {
+  computers: Array<deviceTableRowProps>;
+  mobile_devices: Array<deviceTableRowProps>;
+}
 
 type deviceTableRowProps = {
   codename: string;
@@ -76,249 +88,103 @@ function DeviceTableRow(props: { device: deviceTableRowProps }) {
   );
 }
 
-const computers: Array<deviceTableRowProps> = [
-  {
-    codename: "Roma",
-    status: "In commission",
-    systemType: "MSI B550-A PRO (MS-7C56)",
-    os: "Microsoft Windows 11 Pro for Workstations 24H2",
-    cpu: "AMD Ryzen 7 5700X3D",
-    memory: "32GB (2x16GB) DDR4-3600 UDIMM (XMP)",
-    gpus: ["MSI MECH 2X Radeon RX 6700XT 12GB"],
-    disks: [
-      "NSID 1: 500GB KINGSTON NV2 NVMe PCIe 4.0 x4",
-      "NSID 2: 500GB KINGSTON NV2 NVMe PCIe 4.0 x4",
-      "SATA P0: 500GB Samsung 870 EVO",
-      "SATA P1: 128GB PLEXTOR M8V",
-    ],
-  },
-  {
-    codename: "Milano",
-    status: "In commission",
-    systemType: "Supermicro H11DSI SP3",
-    os: "Proxmox VE 8.2",
-    cpu: "2x AMD EPYC 7642",
-    memory: "256GB (8x32GB) DDR4-2666 ECC RDIMM",
-    gpus: [
-      "GPU 0: AMD Radeon PRO WX2100 2GB",
-      "GPU 1 & 2: NVIDIA RTX A5000 2x24GB",
-    ],
-    disks: [
-      "NSID 1: 1TB WD Black SN850X NVMe PCIe 4.0 x4 (running at PCIe 3.0 x4)",
-      "SATA P0: 500GB Samsung 870 EVO",
-      "RAID 5: 8x 1TB WD Ultrastar DC-HA210",
-    ],
-  },
-  {
-    codename: "Ferrara",
-    status: "In commission",
-    systemType: "OCI VM.Standard.A1.Flex",
-    os: "Canonical Ubuntu 22.04 LTS",
-    cpu: "4-OCPU Ampere Altra AArch64",
-    memory: "24GB",
-    gpus: ["Red Hat Virtio-GPU"],
-    disks: ["200GB block volume"],
-  },
-  {
-    codename: "Maastricht",
-    status: "In commission",
-    systemType: "ASUS VivoBook X1503ZA",
-    os: "Microsoft Windows 11 Pro 24H2",
-    cpu: "Intel Core i3-1220P",
-    memory: "16GB (2x8GB) DDR4-3200 SODIMM",
-    gpus: ["Intel UHD Graphics 64EU"],
-    disks: ["NSID 1: 256GB Micron 2450 NVMe PCIe 4.0 x4"],
-  },
-  {
-    codename: "Burano",
-    status: "In commission",
-    systemType: 'Apple MacBook Pro 13" 2019 (4 Thunderbolt ports)',
-    os: "Apple macOS Sequoia 15.1",
-    cpu: "Intel Core i7-8569U",
-    memory: "16GB LPDDR3-2133 soldered",
-    gpus: ["Intel Iris Plus 655 128MB eDRAM"],
-    disks: ["512GB soldered SSD, NVMe"],
-  },
-  {
-    codename: "Andria",
-    status: "Decommissioned",
-    systemType: "Gigabyte GA-B75M-D3H",
-    os: "Microsoft Windows 10 Pro 22H2",
-    cpu: "Intel Core i7-3770",
-    memory: "16GB (4x4GB) DDR3-1600 UDIMM",
-    gpus: ["NVIDIA GeForce GTX 1050 Ti 4GB"],
-    disks: ["SATA P0: 250GB Samsung 870 EVO", "SATA P1: 128GB Lexar NS100"],
-  },
-  {
-    codename: "Catania",
-    status: "Sold",
-    systemType: "Lenovo ThinkPad W541",
-    os: "Microsoft Windows 11 Pro for Workstations 23H2",
-    cpu: "Intel Core i7-4940XM",
-    memory: "32GB (4x8GB) DDR3L-1600 SODIMM",
-    gpus: ["NVIDIA Quadro K2200M 2GB"],
-    disks: [
-      "SATA P0: 500GB Samsung 870 EVO",
-      "SATA P1 (Ultrabay): 250GB Samsung 860 EVO",
-    ],
-  },
-  {
-    codename: "Trieste",
-    status: "Sold",
-    systemType: "Lenovo ThinkPad E14 Gen 2",
-    os: "Microsoft Windows 11 Pro 22H2",
-    cpu: "Intel Core i7-1165G7",
-    memory: "40GB (8GB soldered DDR4-3200 + 32GB DDR4-3200 SODIMM)",
-    gpus: ["Intel Iris Xe G7 96EU"],
-    disks: [
-      "NSID 1: 500GB WD Blue SN580 NVMe PCIe 4.0 x4",
-      "SATA P0: 250GB Crucial MX500",
-    ],
-  },
-  {
-    codename: "Messina",
-    status: "Decommissioned",
-    systemType: "Lenovo ThinkPad W510",
-    os: "Microsoft Windows 11 Pro 22H2",
-    cpu: "Intel Core i7-720QM",
-    memory: "16GB (4x4GB) DDR3-1333 SODIMM",
-    gpus: ["NVIDIA Quadro FX 880M 1GB"],
-    disks: [
-      "SATA P0: 250GB Samsung 870 EVO",
-      "SATA P1 (Ultrabay): 120GB KINGSTON HyperX",
-    ],
-  },
-  {
-    codename: "Verona",
-    status: "Decommissioned",
-    systemType: "Lenovo ThinkPad X200",
-    os: "Microsoft Windows 11 Home 21H2",
-    cpu: "Intel Core 2 Duo P8600",
-    memory: "6GB (2+4GB) DDR3-1066 SODIMM",
-    gpus: ["Intel GMA 4500MHD"],
-    disks: ["SATA P0: 250GB Samsung 870 EVO"],
-  },
-];
+const page = async () => {
+  try{
+    const devicesResponse = await fetch("https://devicejson.aervnu.moe/");
+    const devices:devicesJsonResponse = await devicesResponse.json();
 
-const mobileDevices: Array<deviceTableRowProps> = [
-  {
-    codename: "Straßburg",
-    status: "In commission",
-    systemType: "Apple iPhone SE 2020",
-    os: "Apple iOS 18.2",
-    cpu: "Apple A13 Bionic",
-    memory: "3GB",
-    gpus: ["Apple GPU (4 core)"],
-    disks: ["64GB"],
-  },
-  {
-    codename: "Zürich",
-    status: "In commission",
-    systemType: "Apple iPhone Xs",
-    os: "Apple iOS 18.2",
-    cpu: "Apple A12 Bionic",
-    memory: "4GB",
-    gpus: ["Apple GPU (4 core)"],
-    disks: ["64GB"],
-  },
-  {
-    codename: "Napoli",
-    status: "In commission",
-    systemType: "Apple iPad Air 4",
-    os: "Apple iPadOS 18.2",
-    cpu: "Apple A14 Bionic",
-    memory: "4GB",
-    gpus: ["Apple GPU (4 core)"],
-    disks: ["256GB"],
-  },
-  {
-    codename: "Köln",
-    status: "Decommissioned",
-    systemType: "Apple iPad Air 1",
-    os: "Apple iOS 12.5.7",
-    cpu: "Apple A7",
-    memory: "1GB",
-    gpus: ["PowerVR G6430"],
-    disks: ["16GB"],
-  },
-  {
-    codename: "Firenze",
-    status: "Decommissioned",
-    systemType: "Microsoft Lumia 950 XL",
-    os: "Microsoft Windows 10 Mobile 1703",
-    cpu: "Qualcomm MSM8994 Snapdragon 810",
-    memory: "3GB",
-    gpus: ["Adreno 430"],
-    disks: ["32GB"],
-  },
-];
+    return (
+      <div className="flex flex-col justify-center text-center">
+        <h1 className="mb-6">
+          <strong>My devices</strong>
+        </h1>
 
-const page = () => {
-  return (
-    <div className="flex flex-col justify-center text-center">
-      <h1 className="mb-6">
-        <strong>My devices</strong>
-      </h1>
+        <div className="flex flex-col justify-center items-center text-center gap-12">
+          <div className="w-full flex flex-col gap-3">
+            <p className="font-bold text-xl w-full text-center">Computers</p>
+            <ScrollArea className="w-full whitespace-nowrap rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-center">Codename</TableHead>
+                    <TableHead className="text-center">Status</TableHead>
+                    <TableHead className="text-center">System type</TableHead>
+                    <TableHead className="text-center">OS</TableHead>
+                    <TableHead className="text-center">CPU</TableHead>
+                    <TableHead className="text-center">Memory</TableHead>
+                    <TableHead className="text-center">GPU</TableHead>
+                    <TableHead className="text-center">Disk(s)</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {devices.computers.map((device, index: number) => (
+                    <DeviceTableRow device={device} key={index} />
+                  ))}
+                </TableBody>
+              </Table>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
+          </div>
 
-      <div className="flex flex-col justify-center items-center text-center gap-12">
-        <div className="w-full flex flex-col gap-3">
-          <p className="font-bold text-xl w-full text-center">Computers</p>
-          <ScrollArea className="w-full whitespace-nowrap rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="text-center">Codename</TableHead>
-                  <TableHead className="text-center">Status</TableHead>
-                  <TableHead className="text-center">System type</TableHead>
-                  <TableHead className="text-center">OS</TableHead>
-                  <TableHead className="text-center">CPU</TableHead>
-                  <TableHead className="text-center">Memory</TableHead>
-                  <TableHead className="text-center">GPU</TableHead>
-                  <TableHead className="text-center">Disk(s)</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {computers.map((device, index: number) => (
-                  <DeviceTableRow device={device} key={index} />
-                ))}
-              </TableBody>
-            </Table>
-            <ScrollBar orientation="horizontal" />
-          </ScrollArea>
+          <div className="border-[1px] w-96 border-[#d9d9d9]"></div>
+
+          <div className="w-full flex flex-col gap-3">
+            <p className="font-bold text-xl w-full text-center">Mobile Devices</p>
+            <ScrollArea className="w-full whitespace-nowrap rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-center">Codename</TableHead>
+                    <TableHead className="text-center">Status</TableHead>
+                    <TableHead className="text-center">System type</TableHead>
+                    <TableHead className="text-center">OS</TableHead>
+                    <TableHead className="text-center">CPU</TableHead>
+                    <TableHead className="text-center">Memory</TableHead>
+                    <TableHead className="text-center">GPU</TableHead>
+                    <TableHead className="text-center">Storage</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {devices.mobile_devices.map((device, index: number) => (
+                    <DeviceTableRow device={device} key={index} />
+                  ))}
+                </TableBody>
+              </Table>
+              <ScrollBar orientation="horizontal" />
+            </ScrollArea>
+          </div>
+
+          <b className="text-white">Stay tuned for more updates!</b>
         </div>
-
-        <div className="border-[1px] w-96 border-[#d9d9d9]"></div>
-
-        <div className="w-full flex flex-col gap-3">
-          <p className="font-bold text-xl w-full text-center">Mobile Devices</p>
-          <ScrollArea className="w-full whitespace-nowrap rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="text-center">Codename</TableHead>
-                  <TableHead className="text-center">Status</TableHead>
-                  <TableHead className="text-center">System type</TableHead>
-                  <TableHead className="text-center">OS</TableHead>
-                  <TableHead className="text-center">CPU</TableHead>
-                  <TableHead className="text-center">Memory</TableHead>
-                  <TableHead className="text-center">GPU</TableHead>
-                  <TableHead className="text-center">Storage</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {mobileDevices.map((device, index: number) => (
-                  <DeviceTableRow device={device} key={index} />
-                ))}
-              </TableBody>
-            </Table>
-            <ScrollBar orientation="horizontal" />
-          </ScrollArea>
-        </div>
-
-        <b className="text-white">Stay tuned for more updates!</b>
       </div>
-    </div>
-  );
+    );
+  } catch (e: unknown){
+    if (e instanceof Error) {
+      return (
+        <div className="flex flex-col justify-center text-center">
+          <h1 className="mb-6">
+            <strong>My devices</strong>
+          </h1>
+
+          <div className="w-full flex flex-col gap-3 items-center">
+            <TriangleAlert color="orange" />
+            <div className="flex flex-col items-center gap-2">
+              <p>Oops. That wasn&apos;t supposed to happen. <a href="/">Head back home?</a></p>
+            </div>
+            <Accordion type="single" collapsible className="w-[50%]">
+              <AccordionItem value="item-1">
+                <AccordionTrigger>Error details</AccordionTrigger>
+                <AccordionContent>
+                  <p>{e.message}</p>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </div>
+        </div>
+      );
+    }
+  }
+
 };
 
 export default page;

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-navigation-menu": "^1.2.1",
     "@radix-ui/react-scroll-area": "^1.2.0",
@@ -32,13 +33,13 @@
     "@types/react-dom": "^18",
     "eslint": "^9.17.0",
     "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
     "globals": "^15.13.0",
     "postcss": "^8",
     "prettier": "3.4.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.6",
     "typescript-eslint": "^8.18.0"
   },
   "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.2
+        version: 1.2.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.2
         version: 2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -273,8 +276,37 @@ packages:
   '@radix-ui/primitive@1.1.0':
     resolution: {integrity: sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==}
 
+  '@radix-ui/primitive@1.1.1':
+    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
+  '@radix-ui/react-accordion@1.2.2':
+    resolution: {integrity: sha512-b1oh54x4DMCdGsB4/7ahiSrViXxaBwRPotiZNnYXjLha9vfuURSAZErki6qjDoSIV0eXx5v57XnTGVtGwnfp2g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.0':
     resolution: {integrity: sha512-FmlW1rCg7hBpEBwFbjHwCW6AmWLQM6g/v0Sn8XbP9NvmSZ2San1FpQeyPtufzOMSIx7Y4dzjlHoifhp+7NkZhw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.2':
+    resolution: {integrity: sha512-PliMB63vxz7vggcyq0IxNYk8vGDrLXVWw4+W4B8YnwI1s18x7YZYqlG9PLX7XxAJUi0g2DxP4XKJMFHh/iVh9A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -299,8 +331,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.1':
+    resolution: {integrity: sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.1':
+    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -457,8 +511,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.2':
+    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.1':
+    resolution: {integrity: sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -498,6 +578,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.1':
+    resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2067,9 +2156,44 @@ snapshots:
 
   '@radix-ui/primitive@1.1.0': {}
 
+  '@radix-ui/primitive@1.1.1': {}
+
+  '@radix-ui/react-accordion@1.2.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collapsible': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-arrow@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-collapsible@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -2088,7 +2212,25 @@ snapshots:
       '@types/react': 18.3.12
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-collection@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -2250,9 +2392,28 @@ snapshots:
       '@types/react': 18.3.12
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-primitive@2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-primitive@2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -2296,6 +2457,13 @@ snapshots:
   '@radix-ui/react-slot@1.1.0(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-slot@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.12

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,55 +10,77 @@ const config: Config = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {
-      colors: {
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
-        },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
-        },
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        chart: {
-          "1": "hsl(var(--chart-1))",
-          "2": "hsl(var(--chart-2))",
-          "3": "hsl(var(--chart-3))",
-          "4": "hsl(var(--chart-4))",
-          "5": "hsl(var(--chart-5))",
-        },
-      },
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-      },
-    },
+  	extend: {
+  		colors: {
+  			background: 'hsl(var(--background))',
+  			foreground: 'hsl(var(--foreground))',
+  			card: {
+  				DEFAULT: 'hsl(var(--card))',
+  				foreground: 'hsl(var(--card-foreground))'
+  			},
+  			popover: {
+  				DEFAULT: 'hsl(var(--popover))',
+  				foreground: 'hsl(var(--popover-foreground))'
+  			},
+  			primary: {
+  				DEFAULT: 'hsl(var(--primary))',
+  				foreground: 'hsl(var(--primary-foreground))'
+  			},
+  			secondary: {
+  				DEFAULT: 'hsl(var(--secondary))',
+  				foreground: 'hsl(var(--secondary-foreground))'
+  			},
+  			muted: {
+  				DEFAULT: 'hsl(var(--muted))',
+  				foreground: 'hsl(var(--muted-foreground))'
+  			},
+  			accent: {
+  				DEFAULT: 'hsl(var(--accent))',
+  				foreground: 'hsl(var(--accent-foreground))'
+  			},
+  			destructive: {
+  				DEFAULT: 'hsl(var(--destructive))',
+  				foreground: 'hsl(var(--destructive-foreground))'
+  			},
+  			border: 'hsl(var(--border))',
+  			input: 'hsl(var(--input))',
+  			ring: 'hsl(var(--ring))',
+  			chart: {
+  				'1': 'hsl(var(--chart-1))',
+  				'2': 'hsl(var(--chart-2))',
+  				'3': 'hsl(var(--chart-3))',
+  				'4': 'hsl(var(--chart-4))',
+  				'5': 'hsl(var(--chart-5))'
+  			}
+  		},
+  		borderRadius: {
+  			lg: 'var(--radius)',
+  			md: 'calc(var(--radius) - 2px)',
+  			sm: 'calc(var(--radius) - 4px)'
+  		},
+  		keyframes: {
+  			'accordion-down': {
+  				from: {
+  					height: '0'
+  				},
+  				to: {
+  					height: 'var(--radix-accordion-content-height)'
+  				}
+  			},
+  			'accordion-up': {
+  				from: {
+  					height: 'var(--radix-accordion-content-height)'
+  				},
+  				to: {
+  					height: '0'
+  				}
+  			}
+  		},
+  		animation: {
+  			'accordion-down': 'accordion-down 0.2s ease-out',
+  			'accordion-up': 'accordion-up 0.2s ease-out'
+  		}
+  	}
   },
   plugins: [animate],
 };


### PR DESCRIPTION
Devices in the `/devices` route will now be fetched from a Cloudflare Worker rather than be hard-coded in the `/devices/page.tsx` file.

This will help with the following:
- Build time will not be wasted when updating the devices list
- Updating the list is now easier

This PR also adds the `accordion.tsx` component from shadcn/ui which is used in the `/devices` page to show collapsible error information in case the fetch function fails.